### PR TITLE
feat: Implement break mode with timer functionality

### DIFF
--- a/TESTING_BREAK_MODE.md
+++ b/TESTING_BREAK_MODE.md
@@ -1,0 +1,68 @@
+# Manual Test Cases for Break Mode Functionality
+
+## Pre-conditions:
+- Ensure `userstart.html` is loaded in a web browser.
+- Ensure JavaScript is enabled.
+- It's helpful to have the browser's developer console open to observe any errors and to manually inspect element states if needed.
+
+## Test Case 1: Initial State Verification
+1.  **Action:** Load `userstart.html`.
+2.  **Expected Outcome:**
+    *   The 'Hello message' (e.g., "Hey, [User Name]") is visible.
+    *   The 'Start' work button is visible.
+    *   The 'Break' button is visible next to the 'Start' work button.
+    *   The main 'Stop' work button's visibility depends on `ajaxcall()` (it might be hidden if no work is active, or visible if work is active - this is existing functionality).
+    *   The timer display ('00:00') is hidden.
+    *   The 'Play', 'Pause', and 'Stop Break' buttons are hidden.
+
+## Test Case 2: Entering Break Mode
+1.  **Action:** Click the 'Break' button.
+2.  **Expected Outcome:**
+    *   The 'Hello message' becomes hidden.
+    *   The 'Start' work button becomes hidden.
+    *   The 'Break' button (the one you just clicked) becomes hidden.
+    *   The main 'Stop' work button becomes hidden.
+    *   The timer display becomes visible, showing '00:00'.
+    *   The 'Play' button becomes visible and is enabled.
+    *   The 'Pause' button becomes visible and is disabled.
+    *   The 'Stop Break' button becomes visible.
+
+## Test Case 3: Timer Functionality - Play and Pause
+1.  **Action (starting from state after Test Case 2):** Click the 'Play' button.
+2.  **Expected Outcome:**
+    *   The timer display starts incrementing every second (e.g., 00:01, 00:02, ...).
+    *   The 'Play' button becomes disabled.
+    *   The 'Pause' button becomes enabled.
+3.  **Action:** Wait for the timer to reach '00:05' (or any few seconds). Click the 'Pause' button.
+4.  **Expected Outcome:**
+    *   The timer display stops incrementing and holds the current time (e.g., '00:05').
+    *   The 'Play' button becomes enabled.
+    *   The 'Pause' button becomes disabled.
+5.  **Action:** Click the 'Play' button again.
+6.  **Expected Outcome:**
+    *   The timer display resumes incrementing from where it left off (e.g., from '00:05' to '00:06', ...).
+    *   The 'Play' button becomes disabled.
+    *   The 'Pause' button becomes enabled.
+
+## Test Case 4: Exiting Break Mode
+1.  **Action (starting from state after Test Case 3, timer can be running or paused):** Click the 'Stop Break' button.
+2.  **Expected Outcome:**
+    *   The 'Hello message' becomes visible again.
+    *   The timer display becomes hidden.
+    *   The 'Play', 'Pause', and 'Stop Break' buttons become hidden.
+    *   The 'Start' work button becomes visible.
+    *   The 'Break' button becomes visible again.
+    *   The main 'Stop' work button's visibility is correctly restored by `ajaxcall()` based on whether a work session was active before the break. (This requires knowing the state prior to break or observing `ajaxcall`'s behavior).
+    *   The break timer value should be reset internally (next time break mode is entered, it starts from 00:00).
+
+## Test Case 5: Interaction with Main Work Flow (Conceptual)
+1.  **Scenario A: No active work session.**
+    *   **Action:** Start with no work session active (main 'Start' work button is visible).
+    *   **Action:** Click 'Break', let timer run, then click 'Stop Break'.
+    *   **Expected Outcome:** Page returns to initial state, main 'Start' work button is visible, main 'Stop' work button is hidden.
+2.  **Scenario B: Active work session.**
+    *   **Action:** Click main 'Start' work button (assuming geolocation allows and it starts). Main 'Stop' work button should become visible.
+    *   **Action:** Click 'Break', let timer run, then click 'Stop Break'.
+    *   **Expected Outcome:** Page returns, 'Hello message', 'Start' work (hidden), 'Break' (visible) buttons are in their correct post-break state. Crucially, the main 'Stop' work button should be visible (restored by `ajaxcall` because work was active).
+    *   **Action:** Click the main 'Stop' work button.
+    *   **Expected Outcome:** Work session stops as per existing functionality.

--- a/userstart.html
+++ b/userstart.html
@@ -57,18 +57,42 @@
             class="logo-start-stop"
           />
         </div>
-        <div class="flex flex-col w-[65%] sm:w-[55%]">
+        <div id="helloMessageContainer" class="flex flex-col w-[65%] sm:w-[55%]">
           <h2>Hey,</h2>
           <h2 id="naamDisplay"></h2>
         </div>
       </div>
 
-      <div class="w-[80%] max-w-[500px] max-h-[80px] mx-auto">
+      <div id="timerDisplayContainer" class="w-[80%] max-w-[500px] mx-auto text-center py-4" style="display: none;">
+        <h1 id="timerDisplay" class="text-4xl font-bold noto-sans-bold">00:00</h1>
+      </div>
+
+      <div class="w-[80%] max-w-[500px] mx-auto flex flex-row gap-2">
         <button
           id="startButton"
-          class="flex flex-row items-center justify-center gap-4 button bg-start-green cursor-pointer"
+          class="flex flex-row items-center justify-center gap-4 button bg-start-green cursor-pointer w-1/2"
         >
           <h2>Start</h2>
+        </button>
+        <button
+          id="breakButton"
+          class="flex flex-row items-center justify-center gap-4 button bg-blue-500 text-white cursor-pointer w-1/2"
+        >
+          <h2>Break</h2>
+        </button>
+      </div>
+
+      <div id="breakControlsContainer" class="w-[80%] max-w-[500px] mx-auto mt-4" style="display: none;">
+        <div class="flex flex-row gap-2 mb-2">
+            <button id="playButton" class="flex flex-row items-center justify-center gap-4 button bg-green-500 text-white cursor-pointer w-1/2">
+                <h2>Play</h2>
+            </button>
+            <button id="pauseButton" class="flex flex-row items-center justify-center gap-4 button bg-yellow-500 text-white cursor-pointer w-1/2">
+                <h2>Pause</h2>
+            </button>
+        </div>
+        <button id="stopBreakButton" class="flex flex-row items-center justify-center gap-4 button bg-red-500 text-white cursor-pointer w-full">
+            <h2>Stop Break</h2>
         </button>
       </div>
 


### PR DESCRIPTION
Adds a 'Break' button to your start page (`userstart.html`) next to the 'Start' work button.

When 'Break' is clicked:
- The main UI (Hello message, Start/Break/Stop work buttons) is hidden.
- A timer (defaulting to 00:00) is displayed.
- 'Play', 'Pause', and 'Stop Break' buttons appear.

Timer controls:
- 'Play': Starts or resumes the timer.
- 'Pause': Pauses the timer.

Exiting break mode:
- Clicking 'Stop Break' reverts the UI to its pre-break state.
- The main work buttons ('Start'/'Stop') visibility is restored based on the actual work session status via `ajaxcall()`.

Modifications:
- `userstart.html`: Added new buttons and timer display elements. Assigned ID `helloMessageContainer` to the greeting message div.
- `js/start.js`: Implemented `toggleBreakMode`, `startBreakTimer`, `pauseBreakTimer` functions and associated event listeners. Ensured new logic does not conflict with existing work timer.
- `TESTING_BREAK_MODE.md`: Added a new file with manual test cases to verify the functionality.